### PR TITLE
fix talisman local options

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,6 +11,7 @@ Contributors
 - Alexander Ioannidis
 - Alizee Pace
 - Esteban J. G. Gabancho
+- Guillaume Viger
 - Jiri Kuncar
 - Krzysztof Nowak
 - Lars Holm Nielsen

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.3.1 (released 2021-11-24)
+
+- Fix *long* standing issue with newer flask-talisman having changed its interface.
+
 Version 1.3.0 (released 2020-12-17)
 
 - Adds theme dependent icons to the settings menu.

--- a/invenio_admin/version.py
+++ b/invenio_admin/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/invenio_admin/views.py
+++ b/invenio_admin/views.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2021 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -40,7 +41,7 @@ def init_menu():
     item.register(
         "admin.index",
         # NOTE: Menu item text (icon replaced by a cogs icon).
-        _('%(icon)s Administration', icon=f'<i class="{current_theme_icons.cogs}"></i>'),
+        _('%(icon)s Administration', icon=f'<i class="{current_theme_icons.cogs}"></i>'),  # noqa
         visible_when=_has_admin_access,
         order=100)
 
@@ -75,8 +76,16 @@ def protected_adminview_factory(base_class):
             """
             invenio_app = current_app.extensions.get('invenio-app', None)
             if invenio_app:
-                setattr(invenio_app.talisman.local_options,
-                        'content_security_policy', None)
+                # Because there seems to be back-and-forth on pinning and
+                # unpinning dependencies, let's support both for now:
+                if hasattr(invenio_app.talisman, 'content_security_policy'):
+                    invenio_app.talisman.content_security_policy = None
+                else:
+                    setattr(
+                        invenio_app.talisman.local_options,
+                        'content_security_policy',
+                        None
+                    )
             return super(ProtectedAdminView, self)._handle_view(name, **kwargs)
 
         def is_accessible(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,6 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --isort --pydocstyle --pycodestyle --doctest-glob="*.rst" --doctest-modules --cov=invenio-admin --cov-report=term-missing
+addopts = --isort --pydocstyle --pycodestyle --doctest-glob="*.rst" --doctest-modules --cov=invenio_admin --cov-report=term-missing
 filterwarnings = ignore::pytest.PytestDeprecationWarning
 testpaths = tests invenio_admin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,8 @@ def app(request):
         SECRET_KEY='SECRET_KEY',
         ADMIN_LOGIN_ENDPOINT='login',
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        APP_THEME=[],
+        THEME_ICONS=[]
     )
     Babel(app)
     InvenioDB(app)


### PR DESCRIPTION
- views: fix flask-talisman compatibility
- release: v1.3.1
- fixes local test
- closes https://github.com/inveniosoftware/invenio-admin/issues/66
- This is needed because it's breaking invenio-app-rdm https://github.com/inveniosoftware/invenio-app-rdm/runs/4299602405?check_suite_focus=true#step:7:119 now that flask-talisman is unpinned. Plus the problem has been around for a long time...